### PR TITLE
Create install path in install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,6 @@ u2f_hidraw_id: u2f_hidraw_id.c
 
 .PHONY: install
 install: all
+	install -d "$(DESTDIR)/lib/udev/rules.d"
 	install -m 644 60-u2f-hidraw.rules "$(DESTDIR)/lib/udev/rules.d/"
 	install u2f_hidraw_id "$(DESTDIR)/lib/udev/"


### PR DESCRIPTION
Creating the install path during "make install" prevents the
need for logic in the packaging code to create it.
