### PR TITLE
Update link to U2F HID specification

### DIFF
--- a/u2f_hidraw_id.c
+++ b/u2f_hidraw_id.c
@@ -125,7 +125,7 @@ int main(int argc, char **argv)
 
                 /*
                  * Detect U2F tokens.  See:
-                 * https://fidoalliance.org/specs/fido-u2f-HID-protocol-v1.0-rd-20141008.pdf
+                 * https://fidoalliance.org/specs/fido-u2f-v1.0-ps-20141009/fido-u2f-hid-protocol-ps-20141009.pdf
                  * http://www.usb.org/developers/hidpage/HUTRR48.pdf
                  */
 


### PR DESCRIPTION
The previous PDF link is dead. This appears to be the most recent version of this specification.

There's also an HTML version of the spec which would allow a direct link to the relevant section: <https://fidoalliance.org/specs/fido-u2f-v1.0-ps-20141009/fido-u2f-hid-protocol-ps-20141009.html#hid-report-descriptor-and-device-discovery>. Would you prefer that?